### PR TITLE
Removed deprecated uses

### DIFF
--- a/IdrisScript.idr
+++ b/IdrisScript.idr
@@ -1,6 +1,6 @@
 module IdrisScript
 
-%access public
+%access public export
 
 JSRef : Type
 JSRef = Ptr
@@ -18,7 +18,7 @@ data JSType = JSNumber
             | JSObject String
             | JSUndefined
 
-instance Eq JSType where
+implementation Eq JSType where
   JSNumber      == JSNumber      = True
   JSString      == JSString      = True
   JSBoolean     == JSBoolean     = True
@@ -75,35 +75,35 @@ where
            return 6;
        })(%0)"""
 
-class ToJS from (to : JSType) where
+interface ToJS from (to : JSType) where
   toJS : from -> JSValue to
 
-instance ToJS String JSString where
+implementation ToJS String JSString where
   toJS str = MkJSString (believe_me str)
 
-instance ToJS Int JSNumber where
+implementation ToJS Int JSNumber where
   toJS num = MkJSNumber (believe_me num)
 
-instance ToJS Float JSNumber where
+implementation ToJS Double JSNumber where
   toJS num = MkJSNumber (believe_me num)
 
-instance ToJS Bool JSBoolean where
+implementation ToJS Bool JSBoolean where
   toJS False = MkJSBoolean (believe_me 0)
   toJS True  = MkJSBoolean (believe_me 1)
 
-class FromJS (from : JSType) to where
+interface FromJS (from : JSType) to where
   fromJS : JSValue from -> to
 
-instance FromJS JSString String where
+implementation FromJS JSString String where
   fromJS (MkJSString str) = believe_me str
 
-instance FromJS JSNumber Int where
-  fromJS (MkJSNumber num) = cast {from=Float} {to=Int} (believe_me num)
+implementation FromJS JSNumber Int where
+  fromJS (MkJSNumber num) = cast {from=Double} {to=Int} (believe_me num)
 
-instance FromJS JSNumber Float where
+implementation FromJS JSNumber Double where
   fromJS (MkJSNumber num) = believe_me num
 
-instance FromJS JSBoolean Bool where
+implementation FromJS JSBoolean Bool where
   fromJS (MkJSBoolean b) = check (believe_me b)
     where
       check : Int -> Bool

--- a/IdrisScript/Arrays.idr
+++ b/IdrisScript/Arrays.idr
@@ -2,7 +2,7 @@ module IdrisScript.Arrays
 
 import IdrisScript
 
-%access public
+%access public export
 
 infixr 7 ++
 

--- a/IdrisScript/Arrays/Unpacked.idr
+++ b/IdrisScript/Arrays/Unpacked.idr
@@ -2,7 +2,7 @@ module IdrisScript.Arrays.Unpacked
 
 import IdrisScript
 
-%access public
+%access public export
 
 singleton : ToJS from to => from -> JS_IO (JSValue JSArray)
 singleton {from} {to} val = do

--- a/IdrisScript/Date.idr
+++ b/IdrisScript/Date.idr
@@ -5,7 +5,7 @@ import public IdrisScript.Date.Months
 import public IdrisScript.Date.Days
 import public IdrisScript.Date.Types
 
-%access public
+%access public export
 
 Date : JS_IO (JSValue JSFunction)
 Date = do

--- a/IdrisScript/Date/Days.idr
+++ b/IdrisScript/Date/Days.idr
@@ -2,7 +2,7 @@ module IdrisScript.Date.Days
 
 import IdrisScript
 
-%access public
+%access public export
 
 data Day = Monday
          | Tuesday
@@ -12,7 +12,7 @@ data Day = Monday
          | Saturday
          | Sunday
 
-instance Eq Day where
+implementation Eq Day where
   Monday    == Monday    = True
   Tuesday   == Tuesday   = True
   Wednesday == Wednesday = True
@@ -22,7 +22,7 @@ instance Eq Day where
   Sunday    == Sunday    = True
   _         == _         = False
 
-instance Cast Day Int where
+implementation Cast Day Int where
   cast Monday    = 1
   cast Tuesday   = 2
   cast Wednesday = 3
@@ -31,7 +31,7 @@ instance Cast Day Int where
   cast Saturday  = 6
   cast Sunday    = 7
 
-instance Cast Day Integer where
+implementation Cast Day Integer where
   cast Monday    = 1
   cast Tuesday   = 2
   cast Wednesday = 3
@@ -40,7 +40,7 @@ instance Cast Day Integer where
   cast Saturday  = 6
   cast Sunday    = 7
 
-instance Cast Day Nat where
+implementation Cast Day Nat where
   cast Monday    = 1
   cast Tuesday   = 2
   cast Wednesday = 3

--- a/IdrisScript/Date/Months.idr
+++ b/IdrisScript/Date/Months.idr
@@ -1,6 +1,6 @@
 module IdrisScript.Date.Months
 
-%access public
+%access public export
 
 data Month = January
            | February
@@ -15,7 +15,7 @@ data Month = January
            | November
            | December
 
-instance Eq Month where
+implementation Eq Month where
   January   == January   = True
   February  == February  = True
   March     == March     = True

--- a/IdrisScript/Date/Types.idr
+++ b/IdrisScript/Date/Types.idr
@@ -3,46 +3,46 @@ module IdrisScript.Date.Types
 import IdrisScript.Date.Months
 import IdrisScript.Date.Days
 
-%access public
+%access public export
 
 record Year where
   constructor MkYear
   unYear : Int
 
-instance Eq Year where
+implementation Eq Year where
   year == year' = unYear year == unYear year'
 
 record Date where
   constructor MkDate
   unDate : Int
 
-instance Eq Date where
+implementation Eq Date where
   date == date' = unDate date == unDate date'
 
 record Hours where
   constructor MkHours
   unHours : Int
 
-instance Eq Hours where
+implementation Eq Hours where
   hours == hours' = unHours hours == unHours hours'
 
 record Minutes where
   constructor MkMinutes
   unMinutes : Int
 
-instance Eq Minutes where
+implementation Eq Minutes where
   mins == mins' = unMinutes mins == unMinutes mins'
 
 record Seconds where
   constructor MkSeconds
   unSeconds : Int
 
-instance Eq Seconds where
+implementation Eq Seconds where
   secs == secs' = unSeconds secs == unSeconds secs'
 
 record Milliseconds where
   constructor MkMilliseconds
   unMilliseconds : Int
 
-instance Eq Milliseconds where
+implementation Eq Milliseconds where
   millis == millis' = unMilliseconds millis == unMilliseconds millis'

--- a/IdrisScript/Functions.idr
+++ b/IdrisScript/Functions.idr
@@ -2,7 +2,7 @@ module IdrisScript.Functions
 
 import IdrisScript
 
-%access public
+%access public export
 
 infixl 6 !!
 

--- a/IdrisScript/Functions/Unpacked.idr
+++ b/IdrisScript/Functions/Unpacked.idr
@@ -2,7 +2,7 @@ module IdrisScript.Functions.Unpacked
 
 import IdrisScript
 
-%access public
+%access public export
 
 setProperty : ToJS from to
            => String

--- a/IdrisScript/JSON.idr
+++ b/IdrisScript/JSON.idr
@@ -2,7 +2,7 @@ module IdrisScript.JSON
 
 import IdrisScript
 
-%access public
+%access public export
 
 ||| Converts an object into a JSON string
 stringfy : JSValue (JSObject c) -> JS_IO String

--- a/IdrisScript/Objects.idr
+++ b/IdrisScript/Objects.idr
@@ -2,7 +2,7 @@ module IdrisScript.Objects
 
 import IdrisScript
 
-%access public
+%access public export
 
 infixl 6 !!
 

--- a/IdrisScript/Objects/Unpacked.idr
+++ b/IdrisScript/Objects/Unpacked.idr
@@ -2,7 +2,7 @@ module IdrisScript.Objects.Unpacked
 
 import IdrisScript
 
-%access public
+%access public export
 
 setProperty : ToJS from to
            => String

--- a/IdrisScript/RegExps.idr
+++ b/IdrisScript/RegExps.idr
@@ -2,7 +2,7 @@ module IdrisScript.RegExps
 
 import IdrisScript
 
-%access public
+%access public export
 
 RegExp : JS_IO (JSValue JSFunction)
 RegExp = do
@@ -13,7 +13,7 @@ data RegExpFlags = Global
                  | IgnoreCase
                  | Multiline
 
-instance Eq RegExpFlags where
+implementation Eq RegExpFlags where
   Global     == Global     = True
   IgnoreCase == IgnoreCase = True
   Multiline  == Multiline  = True

--- a/IdrisScript/Strings.idr
+++ b/IdrisScript/Strings.idr
@@ -2,7 +2,7 @@ module IdrisScript.Strings
 
 import IdrisScript
 
-%access public
+%access public export
 
 ||| Upper case a string.
 toUpperCase : String -> JS_IO String

--- a/IdrisScript/Timer.idr
+++ b/IdrisScript/Timer.idr
@@ -2,7 +2,7 @@ module IdrisScript.Timer
 
 import IdrisScript
 
-%access public
+%access public export
 
 export
 record Timeout where
@@ -23,6 +23,7 @@ setTimeout f millis = do
   return $ MkTimeout timeout
 
 ||| Clears a timeout.
+export
 clearTimeout : Timeout -> JS_IO ()
 clearTimeout timeout =
   jscall "clearTimeout(%0)" (Ptr -> JS_IO ()) (unTimeout timeout)


### PR DESCRIPTION
Recently some keywords were replaced with others.
This commit apply the changes necessary to remove the deprecation warnings.
No test are performed beyond type-checking.

It would be worthwhile to check how the accessibility of some functions and types are affected as I doubt we want `%access public export` in every file.

This fixes #4.
